### PR TITLE
Fix missing redo in toolbar slot

### DIFF
--- a/src/components/VpEditor.vue
+++ b/src/components/VpEditor.vue
@@ -57,7 +57,7 @@ onMounted(() => {
   <div class="vue-paint vp-editor" :class="`active-tool-${settings.tool}`">
     <vp-image ref="vpImage" :tools :activeShape :history :width="widthRef" :height="heightRef" />
 
-    <slot name="toolbar" :setTool :undo :redo :save :reset :settings>
+    <slot name="toolbar" :set-tool :undo :redo :save :reset :settings>
       <vp-toolbar v-model:settings="settings" @set-tool="setTool" @undo="undo" @redo="redo" @save="save" @reset="reset"
         :tools />
     </slot>

--- a/src/components/VpEditor.vue
+++ b/src/components/VpEditor.vue
@@ -57,7 +57,7 @@ onMounted(() => {
   <div class="vue-paint vp-editor" :class="`active-tool-${settings.tool}`">
     <vp-image ref="vpImage" :tools :activeShape :history :width="widthRef" :height="heightRef" />
 
-    <slot name="toolbar" :set-tool :undo :save :reset :settings>
+    <slot name="toolbar" :setTool :undo :redo :save :reset :settings>
       <vp-toolbar v-model:settings="settings" @set-tool="setTool" @undo="undo" @redo="redo" @save="save" @reset="reset"
         :tools />
     </slot>


### PR DESCRIPTION
The redo at your custom toolbar example (https://robertrosman.github.io/vue-paint/) doesn't work.
The redo slot propertie is missing.